### PR TITLE
BufferedStream: Implement leave open

### DIFF
--- a/src/Amicitia.IO/Binary/BinaryValueReader.cs
+++ b/src/Amicitia.IO/Binary/BinaryValueReader.cs
@@ -426,7 +426,7 @@ namespace Amicitia.IO.Binary
             else
             {
                 // Block buffered
-                mBaseStream = new CachedBlockBufferedStream( input, blockSize );
+                mBaseStream = new CachedBlockBufferedStream( input, blockSize, leaveOpen: mLeaveOpen );
             }
 
             FilePath = fileName;

--- a/src/Amicitia.IO/Binary/BinaryValueWriter.cs
+++ b/src/Amicitia.IO/Binary/BinaryValueWriter.cs
@@ -444,7 +444,7 @@ namespace Amicitia.IO.Binary
             else
             {
                 // Block buffered
-                mBaseStream = new CachedBlockBufferedStream( input, blockSize );
+                mBaseStream = new CachedBlockBufferedStream( input, blockSize, leaveOpen: mLeaveOpen );
             }
 
             FilePath = fileName;


### PR DESCRIPTION
This PR fixes a problem where disposing BinaryValueReader wouldn't dispose the base stream when ownership is transferred because, CachedBlockBufferedStream doesn't dispose the base stream.