### PR TITLE
Fix small struct types not getting their fields endian swapped

### DIFF
--- a/src/Amicitia.IO/Binary/BinaryOperations.cs
+++ b/src/Amicitia.IO/Binary/BinaryOperations.cs
@@ -31,17 +31,17 @@ namespace Amicitia.IO.Binary
         {
             if ( typeof( T ) == typeof( byte ) || typeof( T ) == typeof( sbyte ) )
                 return;
-            else if ( typeof( T ) == typeof( short ) || typeof( T ) == typeof( ushort ) || Unsafe.SizeOf<T>() == sizeof( short ) )
+            else if ( typeof( T ) == typeof( short ) || typeof( T ) == typeof( ushort ) || ( Unsafe.SizeOf<T>() == sizeof( short ) && value is Enum ) )
             {
                 var reversedValue = BinaryPrimitives.ReverseEndianness( Unsafe.As<T, ushort>( ref value ) );
                 value = Unsafe.As<ushort, T>( ref reversedValue );
             }
-            else if ( typeof( T ) == typeof( int ) || typeof( T ) == typeof( uint ) || typeof( T ) == typeof( float ) || Unsafe.SizeOf<T>() == sizeof( int ) )
+            else if ( typeof( T ) == typeof( int ) || typeof( T ) == typeof( uint ) || typeof( T ) == typeof( float ) || ( Unsafe.SizeOf<T>() == sizeof( int ) && value is Enum ) )
             {
                 var reversedValue = BinaryPrimitives.ReverseEndianness( Unsafe.As<T, uint>( ref value ) );
                 value = Unsafe.As<uint, T>( ref reversedValue );
             }
-            else if ( typeof( T ) == typeof( long ) || typeof( T ) == typeof( ulong ) || typeof( T ) == typeof( double ) || Unsafe.SizeOf<T>() == sizeof( long ) )
+            else if ( typeof( T ) == typeof( long ) || typeof( T ) == typeof( ulong ) || typeof( T ) == typeof( double ) || ( Unsafe.SizeOf<T>() == sizeof( long ) && value is Enum ) )
             {
                 var reversedValue = BinaryPrimitives.ReverseEndianness( Unsafe.As<T, ulong>( ref value ) );
                 value = Unsafe.As<ulong, T>( ref reversedValue );

--- a/src/Amicitia.IO/Binary/Utilities/TypeBinaryReverseMethodGenerator.cs
+++ b/src/Amicitia.IO/Binary/Utilities/TypeBinaryReverseMethodGenerator.cs
@@ -60,17 +60,17 @@ namespace Amicitia.IO.Binary.Utilities
             // Manually inlined BinaryOperations<T>.Reverse( value )
             if ( typeof( T ) == typeof( byte ) || typeof( T ) == typeof( sbyte ) )
                 return;
-            else if ( typeof( T ) == typeof( short ) || typeof( T ) == typeof( ushort ) || Unsafe.SizeOf<T>() == sizeof( short ) )
+            else if ( typeof( T ) == typeof( short ) || typeof( T ) == typeof( ushort ) || ( Unsafe.SizeOf<T>() == sizeof( short ) && value is Enum ) )
             {
                 var reversedValue = BinaryPrimitives.ReverseEndianness( Unsafe.As<T, ushort>( ref value ) );
                 value = Unsafe.As<ushort, T>( ref reversedValue );
             }
-            else if ( typeof( T ) == typeof( int ) || typeof( T ) == typeof( uint ) || typeof( T ) == typeof( float ) || Unsafe.SizeOf<T>() == sizeof(int))
+            else if (typeof(T) == typeof(int) || typeof(T) == typeof(uint) || typeof(T) == typeof(float) || (Unsafe.SizeOf<T>() == sizeof(int) && value is Enum))
             {
                 var reversedValue = BinaryPrimitives.ReverseEndianness( Unsafe.As<T, uint>( ref value ) );
                 value = Unsafe.As<uint, T>( ref reversedValue );
             }
-            else if ( typeof( T ) == typeof( long ) || typeof( T ) == typeof( ulong ) || typeof( T ) == typeof( double ) || Unsafe.SizeOf<T>() == sizeof(long))
+            else if ( typeof( T ) == typeof( long ) || typeof( T ) == typeof( ulong ) || typeof( T ) == typeof( double ) || ( Unsafe.SizeOf<T>() == sizeof(long) && value is Enum ))
             {
                 var reversedValue = BinaryPrimitives.ReverseEndianness( Unsafe.As<T, ulong>( ref value ) );
                 value = Unsafe.As<ulong, T>( ref reversedValue );


### PR DESCRIPTION
This PR adds enum type checks in Reverse methods. `value is Enum` was used as opposed `typeof(T).IsEnum` is because the latter makes the JIT emit un-necessary instructions.

JIT Asm emitted by the current implementation:
https://sharplab.io/#gist:5b98d4bc1093e9fa28ea5ab7b9f8ca7b