### PR TITLE
Implement recursive offset flush mode.

### DIFF
--- a/src/Amicitia.IO/Binary/OffsetFlushMode.cs
+++ b/src/Amicitia.IO/Binary/OffsetFlushMode.cs
@@ -1,0 +1,8 @@
+﻿namespace Amicitia.IO.Binary
+{
+    public enum OffsetFlushMode
+    {
+        Linear,
+        Recursive
+    }
+}


### PR DESCRIPTION
Adds a recursive offset flush mode, where the children offset writes are placed immediately after their parent in the file. This is the behavior commonly seen in file formats.

Opt-in by default to not break existing writers. This also made it possible to implement a priority parameter for the recursive flush mode specifically.