### PR TITLE
Fix reading and writing null-terminated Unicode strings

### DIFF
--- a/src/Amicitia.IO/Binary/BinaryValueWriter.cs
+++ b/src/Amicitia.IO/Binary/BinaryValueWriter.cs
@@ -265,15 +265,28 @@ namespace Amicitia.IO.Binary
         [MethodImpl( MethodImplOptions.AggressiveInlining )]
         public void WriteStringNullTerminated( Encoding encoding, string value )
         {
+            bool isUnicode = encoding == Encoding.Unicode || encoding == Encoding.BigEndianUnicode;
+
             FlushBits();
+
             if ( string.IsNullOrEmpty( value ) )
             {
-                Write<byte>(0);
+                if ( isUnicode )
+                    Write<ushort>( 0 );
+                else
+                    Write<byte>( 0 );
+                
                 return;
             }
+
             var bytes = encoding.GetBytes( value );
+
             WriteArray( bytes );
-            Write<byte>( 0 );
+
+            if ( isUnicode )
+                Write<ushort>( 0 );
+            else
+                Write<byte>( 0 );
         }
 
         public void WriteStringFixedLength( Encoding encoding, string value, int fixedLength )


### PR DESCRIPTION
- Fixed `ReadString` when specifying `Encoding.Unicode` or `Encoding.BigEndianUnicode` with `StringBinaryFormat.NullTerminated`, as it was only checking for a null byte terminator rather than a null ushort, causing it to stop reading prematurely.
- Fixed `WriteStringNullTerminated` so that it terminates a Unicode string with a null ushort instead of a null byte.
- Fixed `StringBinaryFormat.FixedLength` not reading all Unicode characters, although it assumes the user specified the length in bytes instead of characters for now.