### PR TITLE
Use out parameter ReadNative implementation internally

### DIFF
--- a/src/Amicitia.IO/Binary/BinaryValueReader.cs
+++ b/src/Amicitia.IO/Binary/BinaryValueReader.cs
@@ -86,7 +86,7 @@ namespace Amicitia.IO.Binary
 
         public T Read<T>() where T : unmanaged
         {
-            var value = ReadNative<T>();
+            ReadNative<T>( out var value );
             if ( Unsafe.SizeOf<T>() != 1 && IsSwappingNeeded() )
                 BinaryOperations<T>.Reverse( ref value );
 
@@ -107,7 +107,7 @@ namespace Amicitia.IO.Binary
         /// <returns></returns>
         public T ReadLittle<T>() where T : unmanaged
         {
-            var value = ReadNative<T>();
+            ReadNative<T>( out var value );
             if ( Unsafe.SizeOf<T>() != 1 && !BitConverter.IsLittleEndian )
                 BinaryOperations<T>.Reverse( ref value );
 
@@ -133,7 +133,7 @@ namespace Amicitia.IO.Binary
         /// <returns></returns>
         public T ReadBig<T>() where T : unmanaged
         {
-            var value = ReadNative<T>();
+            ReadNative<T>( out var value );
             if ( Unsafe.SizeOf<T>() != 1 && BitConverter.IsLittleEndian )
                 BinaryOperations<T>.Reverse( ref value );
 
@@ -160,7 +160,7 @@ namespace Amicitia.IO.Binary
             return value;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl( MethodImplOptions.AggressiveInlining )]
         public void ReadNative<T>( out T value ) where T : unmanaged
         {
             if ( typeof( T ) == typeof( byte ) || typeof( T ) == typeof( sbyte ) )


### PR DESCRIPTION
Workaround for a bizarre issue that seems to be related to .NET.

Certain floats when read by the `ReadNative<T>()` helper are returned as a malformed value.

```cs
[MethodImpl( MethodImplOptions.AggressiveInlining )]
public T ReadNative<T>() where T : unmanaged
{
    ReadNative<T>( out var value );
    // value is correct here
    return value;
    // value is incorrect here
}
```

This PR replaces the internal use of this helper function with the main `ReadNative<T>(out)` method instead. Removing the inlining attributes doesn't solve this problem. This "fixes" the issue in a way I can only describe as magic.

[Marathon](https://github.com/hyperbx/Marathon/tree/v2.0.0) v2 uses Amicitia.IO and has an application to test all binary file exports to make sure they were identical. These tests started failing spontaneously recently until I made these changes to this library.

Once floats are read incorrectly by Amicitia.IO, they're written back to the file as the incorrect value, causing tests to fail.

For example, in Sonic '06, the file `./xenon/archives/enemy.arc/xenon/enemy/ShotParameter.bin` has an array of structures with one field in particular that uses a common value of:
```
9999999.0 | 4B 18 96 7F (big-endian)
```

Amicitia.IO would read this value correctly first, then return it as:
```
10016383.0 | 4B 18 D6 7F (big-endian)
```

.NET version: 10.0.100-preview.5.25277.114
.NET target: .NET Standard 2.1